### PR TITLE
Prevent error on wholly unused stylesheets

### DIFF
--- a/noUnusedStylesRule.ts
+++ b/noUnusedStylesRule.ts
@@ -35,11 +35,11 @@ class NoUnusedStylesWalker extends Lint.RuleWalker {
 
   public visitEndOfFileToken(node: ts.EndOfFileToken) {
     Object.entries(this.stylesheets).forEach(([variableName, stylesheet]) => {
+      const usedPropsForStyleSheet = this.usedProperties[variableName];
       stylesheet.forEach(child => {
         if (
           ts.isPropertyAssignment(child) &&
-          (!this.usedProperties[variableName] ||
-            !this.usedProperties[variableName].includes(child.name.getText()))
+          (!usedPropsForStyleSheet || !usedPropsForStyleSheet.includes(child.name.getText()))
         ) {
           this.addFailure(
             this.createFailure(child.getStart(), child.getWidth(), Rule.FAILURE_STRING),

--- a/noUnusedStylesRule.ts
+++ b/noUnusedStylesRule.ts
@@ -38,7 +38,8 @@ class NoUnusedStylesWalker extends Lint.RuleWalker {
       stylesheet.forEach(child => {
         if (
           ts.isPropertyAssignment(child) &&
-          !this.usedProperties[variableName].includes(child.name.getText())
+          (!this.usedProperties[variableName] ||
+            !this.usedProperties[variableName].includes(child.name.getText()))
         ) {
           this.addFailure(
             this.createFailure(child.getStart(), child.getWidth(), Rule.FAILURE_STRING),


### PR DESCRIPTION
```
import React from 'react';
import { Text } from 'react-native';

export default function MyComponent() {
  return <Text>I don't use styles</Text>;
}

const styles = StyleSheet.create({
  text: {
    color: 'red',
  },
});
```

*Current behaviour*
```
The 'no-unused-styles' rule threw an error in '/path/to/MyComponent.tsx':
TypeError: Cannot read property 'includes' of undefined
    at /path/to/node_modules/tslint-react-native/dist/noUnusedStylesRule.js:68:57
```

*New behaviour*
```
ERROR: /path/to/MyComponent.tsx:9:3 - This style is not used
```

